### PR TITLE
Allows users to override faraday connection options

### DIFF
--- a/lib/github_api/connection.rb
+++ b/lib/github_api/connection.rb
@@ -61,6 +61,7 @@ module Github
       clear_cache unless options.empty?
       builder = api.stack ? api.stack : stack(options.merge!(api: api))
       connection_options.merge!(builder: builder)
+      connection_options.deep_merge!(options[:connection_options]) if options[:connection_options]
       if ENV['DEBUG']
         p "Connection options : \n"
         pp connection_options


### PR DESCRIPTION
This allows you to provide extra connection option to send on to faraday.  This also allows modifying/adding headers during initialization so we can do something like this:

```ruby
Github.new do |config|
    config.basic_auth         = "user:password"
    config.connection_options = {headers: {"X-GitHub-OTP" => '12345'}}
end
```

Related to and solves: #164 and #152 