### PR TITLE
fix example in comment, need '.repos'

### DIFF
--- a/lib/github_api/client/repos/collaborators.rb
+++ b/lib/github_api/client/repos/collaborators.rb
@@ -33,7 +33,7 @@ module Github
     #
     # @example
     #  github = Github.new
-    #  github.collaborators.add 'user', 'repo', 'username'
+    #  github.repos.collaborators.add 'user', 'repo', 'username'
     #
     # @example
     #  collaborators = Github::Repos::Collaborators.new


### PR DESCRIPTION
Hi I think this example doesn't work, so I changed this as following.

```ruby
    #  github = Github.new
    #  github.collaborators.add 'user', 'repo', 'username'
```

change to

```ruby
    #  github = Github.new
    #  github.repos.collaborators.add 'user', 'repo', 'username'
```

I hope this is right. Thanks.
