### PR TITLE
Change Github::Repos class name to the real one

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,13 +563,13 @@ github = Github.new auto_pagination: true
 Depending at what stage you pass the `auto_pagination` it will affect all or only a single request. For example, in order to auto paginate all Repository API methods do:
 
 ```ruby
-Github::Repos.new auto_pagination: true
+Github::Сlient::Repos.new auto_pagination: true
 ```
 
 However, to only auto paginate results for a single request do:
 
 ```ruby
-Github::Repos.new.list user: '...', auto_pagination: true
+Github::Client::Repos.new.list user: '...', auto_pagination: true
 ```
 
 ## 5 Error Handling


### PR DESCRIPTION
I lost about 15 mins trying to understand why it did not require this class to my application and then I realised that there no even such class. I think it's just a typo.